### PR TITLE
fix: Apply filters from chips

### DIFF
--- a/src/components/chip.component.tsx
+++ b/src/components/chip.component.tsx
@@ -1,8 +1,7 @@
 import { Chip, ChipProps } from '@mui/material';
-import * as React from 'react';
-import { StoreContext } from '../context/store.context';
-import type { ICategoryView } from '../types/category.type';
-import type { IPaymentMethodView } from '../types/paymentMethod.type';
+import React from 'react';
+import { StoreContext } from '../context/';
+import type { ICategoryView, IPaymentMethodView } from '../types/';
 
 export type CategoryChipProps = { category: ICategoryView } & ChipProps;
 export type PaymentMethodChipProps = { paymentMethod: IPaymentMethodView } & ChipProps;

--- a/src/components/filter-drawer.component.tsx
+++ b/src/components/filter-drawer.component.tsx
@@ -119,6 +119,10 @@ export const FilterDrawer: React.FC<IFilterDrawerProps> = () => {
     },
   };
 
+  React.useEffect(() => {
+    setUnappliedFilter(filter);
+  }, [filter]);
+
   return (
     <FormDrawer
       open={showFilter}


### PR DESCRIPTION
Make 'em show up when triggered by chip and opend in the filter-drawer